### PR TITLE
remove moment locales from build and generate stats reports

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -42,7 +42,7 @@
 
 * `next-react-app-scripts`
 
-  * [#11](hhttps://github.com/guestlinelabs/create-next-react-app/pull/11) Updated @zeit/next-css from 0.1.5 to 0.2.0
+  * [#11](https://github.com/guestlinelabs/create-next-react-app/pull/11) Updated @zeit/next-css from 0.1.5 to 0.2.0
 
 ## 2.0.0 (June 25, 2018)
 
@@ -96,7 +96,7 @@
 
 * `next-react-app-scripts`
 
-  * [#4](hhttps://github.com/guestlinelabs/create-next-react-app/pull/4) Add an array of valid extensions for the assets generation.
+  * [#4](https://github.com/guestlinelabs/create-next-react-app/pull/4) Add an array of valid extensions for the assets generation.
 
 ## 1.0.1 (Apr 14, 2018)
 
@@ -104,7 +104,7 @@
 
 * `next-react-app-scripts`
 
-  * [#2](hhttps://github.com/guestlinelabs/create-next-react-app/pull/2) Some code cleanup.
+  * [#2](https://github.com/guestlinelabs/create-next-react-app/pull/2) Some code cleanup.
 
 ## 1.0.0 (Apr 13, 2018)
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,19 +2,19 @@
 
 #### :boom: Breaking Change
 
-* `react-scripts`
+* `next-react-app-scripts`
   * [#15](https://github.com/guestlinelabs/create-next-react-app/pull/15) Remove moment locales from the Webpack build (like [CRA does](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#momentjs-locales-are-missing)).
 
 #### :nail_care: Enhancement
 
-* `react-scripts`
+* `next-react-app-scripts`
   * [#15](https://github.com/guestlinelabs/create-next-react-app/pull/15) Generate HTML stats report for both the client and the server on the build folder.
 
 ## 2.0.4 (August 9, 2018)
 
 #### :bug: Bug Fix
 
-* `react-scripts`
+* `next-react-app-scripts`
 
   * [#14](https://github.com/guestlinelabs/create-next-react-app/pull/14) Fix path for the server build since it was changed in Next 6.
 
@@ -22,14 +22,14 @@
 
 #### :house: Internal
 
-* `react-scripts`
+* `next-react-app-scripts`
   * [#13](hhttps://github.com/guestlinelabs/create-next-react-app/pull/13) Updated Next.js from 6.0.3 to 6.1.1
 
 ## 2.0.2 (June 27, 2018)
 
 #### :bug: Bug Fix
 
-* `react-scripts`
+* `next-react-app-scripts`
 
   * [#12](https://github.com/guestlinelabs/create-next-react-app/pull/12) Fixed issue with the static folder for CDNs.
 
@@ -37,21 +37,21 @@
 
 #### :house: Internal
 
-* `react-scripts`
+* `next-react-app-scripts`
   * [#11](hhttps://github.com/guestlinelabs/create-next-react-app/pull/11) Updated @zeit/next-css from 0.1.5 to 0.2.0
 
 ## 2.0.0 (June 25, 2018)
 
 #### :boom: Breaking Change
 
-* `react-scripts`
+* `next-react-app-scripts`
   * [#10](https://github.com/guestlinelabs/create-next-react-app/pull/10) Upgrade Next.js from version 5 to 6.
 
 ## 1.0.8 (May 18, 2018)
 
 #### :bug: Bug Fix
 
-* `react-scripts`
+* `next-react-app-scripts`
 
   * [#9](https://github.com/guestlinelabs/create-next-react-app/pull/9) Fixed issue where the path creation in babel didn't work on Windows.
 
@@ -59,7 +59,7 @@
 
 #### :bug: Bug Fix
 
-* `react-scripts`
+* `next-react-app-scripts`
 
   * [#8](https://github.com/guestlinelabs/create-next-react-app/pull/8) Fixed issue where the chunks filders were not copied to the folder when using PUBLIC_URL.
 
@@ -67,13 +67,13 @@
 
 #### :bug: Bug Fix
 
-* `react-scripts`
+* `next-react-app-scripts`
 
   * [#7](https://github.com/guestlinelabs/create-next-react-app/pull/7) Fixed issue where the chunks folder wasn't generated when using PUBLIC_URL.
 
 #### :memo: Documentation
 
-* `react-scripts`
+* `next-react-app-scripts`
 
   * [#6](https://github.com/guestlinelabs/create-next-react-app/pull/6) Add documentation for the use of extra polyfills.
 
@@ -81,21 +81,21 @@
 
 #### :nail_care: Enhancement
 
-* `react-scripts`
+* `next-react-app-scripts`
   * [#5](https://github.com/guestlinelabs/create-next-react-app/pull/5) Add the posibility of using more polyfills by creating a polyfills.js file inside your src folder.
 
 ## 1.0.3 (Apr 26, 2018)
 
 #### :house: Internal
 
-* `react-scripts`
+* `next-react-app-scripts`
   * [#4](hhttps://github.com/guestlinelabs/create-next-react-app/pull/4) Add an array of valid extensions for the assets generation.
 
 ## 1.0.1 (Apr 14, 2018)
 
 #### :house: Internal
 
-* `react-scripts`
+* `next-react-app-scripts`
   * [#2](hhttps://github.com/guestlinelabs/create-next-react-app/pull/2) Some code cleanup.
 
 ## 1.0.0 (Apr 13, 2018)

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -23,7 +23,7 @@
 #### :house: Internal
 
 * `next-react-app-scripts`
-  * [#13](hhttps://github.com/guestlinelabs/create-next-react-app/pull/13) Updated Next.js from 6.0.3 to 6.1.1
+  * [#13](https://github.com/guestlinelabs/create-next-react-app/pull/13) Updated Next.js from 6.0.3 to 6.1.1
 
 ## 2.0.2 (June 27, 2018)
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,11 +3,13 @@
 #### :boom: Breaking Change
 
 * `next-react-app-scripts`
+
   * [#15](https://github.com/guestlinelabs/create-next-react-app/pull/15) Remove moment locales from the Webpack build (like [CRA does](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#momentjs-locales-are-missing)).
 
 #### :nail_care: Enhancement
 
 * `next-react-app-scripts`
+
   * [#15](https://github.com/guestlinelabs/create-next-react-app/pull/15) Generate HTML stats report for both the client and the server on the build folder.
 
 ## 2.0.4 (August 9, 2018)
@@ -23,6 +25,7 @@
 #### :house: Internal
 
 * `next-react-app-scripts`
+
   * [#13](https://github.com/guestlinelabs/create-next-react-app/pull/13) Updated Next.js from 6.0.3 to 6.1.1
 
 ## 2.0.2 (June 27, 2018)
@@ -38,6 +41,7 @@
 #### :house: Internal
 
 * `next-react-app-scripts`
+
   * [#11](hhttps://github.com/guestlinelabs/create-next-react-app/pull/11) Updated @zeit/next-css from 0.1.5 to 0.2.0
 
 ## 2.0.0 (June 25, 2018)
@@ -45,6 +49,7 @@
 #### :boom: Breaking Change
 
 * `next-react-app-scripts`
+
   * [#10](https://github.com/guestlinelabs/create-next-react-app/pull/10) Upgrade Next.js from version 5 to 6.
 
 ## 1.0.8 (May 18, 2018)
@@ -82,6 +87,7 @@
 #### :nail_care: Enhancement
 
 * `next-react-app-scripts`
+
   * [#5](https://github.com/guestlinelabs/create-next-react-app/pull/5) Add the posibility of using more polyfills by creating a polyfills.js file inside your src folder.
 
 ## 1.0.3 (Apr 26, 2018)
@@ -89,6 +95,7 @@
 #### :house: Internal
 
 * `next-react-app-scripts`
+
   * [#4](hhttps://github.com/guestlinelabs/create-next-react-app/pull/4) Add an array of valid extensions for the assets generation.
 
 ## 1.0.1 (Apr 14, 2018)
@@ -96,6 +103,7 @@
 #### :house: Internal
 
 * `next-react-app-scripts`
+
   * [#2](hhttps://github.com/guestlinelabs/create-next-react-app/pull/2) Some code cleanup.
 
 ## 1.0.0 (Apr 13, 2018)

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,103 @@
+## 3.0.0 (August 17, 2018)
+
+#### :boom: Breaking Change
+
+* `react-scripts`
+  * [#15](https://github.com/guestlinelabs/create-next-react-app/pull/15) Remove moment locales from the Webpack build (like [CRA does](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#momentjs-locales-are-missing)).
+
+#### :nail_care: Enhancement
+
+* `react-scripts`
+  * [#15](https://github.com/guestlinelabs/create-next-react-app/pull/15) Generate HTML stats report for both the client and the server on the build folder.
+
+## 2.0.4 (August 9, 2018)
+
+#### :bug: Bug Fix
+
+* `react-scripts`
+
+  * [#14](https://github.com/guestlinelabs/create-next-react-app/pull/14) Fix path for the server build since it was changed in Next 6.
+
+## 2.0.3 (August 8, 2018)
+
+#### :house: Internal
+
+* `react-scripts`
+  * [#13](hhttps://github.com/guestlinelabs/create-next-react-app/pull/13) Updated Next.js from 6.0.3 to 6.1.1
+
+## 2.0.2 (June 27, 2018)
+
+#### :bug: Bug Fix
+
+* `react-scripts`
+
+  * [#12](https://github.com/guestlinelabs/create-next-react-app/pull/12) Fixed issue with the static folder for CDNs.
+
+## 2.0.1 (June 27, 2018)
+
+#### :house: Internal
+
+* `react-scripts`
+  * [#11](hhttps://github.com/guestlinelabs/create-next-react-app/pull/11) Updated @zeit/next-css from 0.1.5 to 0.2.0
+
+## 2.0.0 (June 25, 2018)
+
+#### :boom: Breaking Change
+
+* `react-scripts`
+  * [#10](https://github.com/guestlinelabs/create-next-react-app/pull/10) Upgrade Next.js from version 5 to 6.
+
+## 1.0.8 (May 18, 2018)
+
+#### :bug: Bug Fix
+
+* `react-scripts`
+
+  * [#9](https://github.com/guestlinelabs/create-next-react-app/pull/9) Fixed issue where the path creation in babel didn't work on Windows.
+
+## 1.0.6 (May 10, 2018)
+
+#### :bug: Bug Fix
+
+* `react-scripts`
+
+  * [#8](https://github.com/guestlinelabs/create-next-react-app/pull/8) Fixed issue where the chunks filders were not copied to the folder when using PUBLIC_URL.
+
+## 1.0.5 (May 10, 2018)
+
+#### :bug: Bug Fix
+
+* `react-scripts`
+
+  * [#7](https://github.com/guestlinelabs/create-next-react-app/pull/7) Fixed issue where the chunks folder wasn't generated when using PUBLIC_URL.
+
+#### :memo: Documentation
+
+* `react-scripts`
+
+  * [#6](https://github.com/guestlinelabs/create-next-react-app/pull/6) Add documentation for the use of extra polyfills.
+
+## 1.0.4 (May 2, 2018)
+
+#### :nail_care: Enhancement
+
+* `react-scripts`
+  * [#5](https://github.com/guestlinelabs/create-next-react-app/pull/5) Add the posibility of using more polyfills by creating a polyfills.js file inside your src folder.
+
+## 1.0.3 (Apr 26, 2018)
+
+#### :house: Internal
+
+* `react-scripts`
+  * [#4](hhttps://github.com/guestlinelabs/create-next-react-app/pull/4) Add an array of valid extensions for the assets generation.
+
+## 1.0.1 (Apr 14, 2018)
+
+#### :house: Internal
+
+* `react-scripts`
+  * [#2](hhttps://github.com/guestlinelabs/create-next-react-app/pull/2) Some code cleanup.
+
+## 1.0.0 (Apr 13, 2018)
+
+First version!

--- a/packages/next-react-app-scripts/README.md
+++ b/packages/next-react-app-scripts/README.md
@@ -24,6 +24,7 @@ We support all the default options that NextJS provides by using their `next/bab
 * [Config](#use-your-own-config)
 * [Polyfills](#use-polyfills)
 * [Tests](#tests)
+* [Moment.js locales](#momentjs-locales)
 
 ## Folder Structure
 
@@ -227,3 +228,29 @@ import 'core-js/fn/array/from';
 ## Tests
 
 By default the `test` command is using [`jest-run`](https://github.com/guestlinelabs/jest-run). Refer to its documentation to see how to work with it.
+
+## Moment.js locales
+
+If you use a [Moment.js](https://momentjs.com/), you might notice that only the English locale is available by default. This is because the locale files are large, and you probably only need a subset of [all the locales provided by Moment.js](https://momentjs.com/#multiple-locale-support).
+
+To add a specific Moment.js locale to your bundle, you need to import it explicitly.<br>
+For example:
+
+```js
+import moment from 'moment';
+import 'moment/locale/fr';
+```
+
+If import multiple locales this way, you can later switch between them by calling `moment.locale()` with the locale name:
+
+```js
+import moment from 'moment';
+import 'moment/locale/fr';
+import 'moment/locale/es';
+
+// ...
+
+moment.locale('fr');
+```
+
+This will only work for locales that have been explicitly imported before.

--- a/packages/next-react-app-scripts/config.js
+++ b/packages/next-react-app-scripts/config.js
@@ -9,16 +9,27 @@ const packageJSON = require(paths.packageJSON);
 module.exports = withCSS({
   distDir: path.join('..', '..', 'build'),
   assetPrefix: process.env.PUBLIC_URL || '',
-  generateBuildId: async () => {
+  generateBuildId() {
     process.env.NEXT_BUILD_ID = Date.now();
 
-    return process.env.NEXT_BUILD_ID;
+    return Promise.resolve(process.env.NEXT_BUILD_ID);
   },
-  webpack: function (config, options) {
+  webpack(config, options) {
     if (packageJSON.name) {
       config.output.jsonpFunction =
         'webpackJsonp' + camelCase(packageJSON.name, { pascalCase: true });
     }
+
+    config.plugins.push(
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      new BundleAnalyzerPlugin({
+        analyzerMode: 'static',
+        analyzerPort: options.isServer ? 8888 : 8889,
+        openAnalyzer: false,
+        reportFilename: `report-${options.isServer ? 'server' : 'client'}.html`,
+        logLevel: 'error'
+      })
+    );
 
     const originalEntry = config.entry;
     config.entry = () => {

--- a/packages/next-react-app-scripts/package-lock.json
+++ b/packages/next-react-app-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "next-react-app-scripts",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/next-react-app-scripts/package.json
+++ b/packages/next-react-app-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-react-app-scripts",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "repository": "guestlinelabs/create-next-react-app",
   "description": "Configuration and scripts for Create Next React App.",
   "license": "MIT",


### PR DESCRIPTION
Following what [CRA does](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#momentjs-locales-are-missing), I removed the moment locales from the build, so it will be way smaller. 

As this is a breaking change, I updated the major version.

Also, add some stats report on html for bundles that will be generated on the build folder.

Added a [CHANGELOG](https://github.com/guestlinelabs/create-next-react-app/blob/381d9cdcc95b6c9bf8aeeaf470e8e3881aa6686c/CHANGELOG.MD) too :)